### PR TITLE
fix 'GAME MODE NULL' being spammed

### DIFF
--- a/Utilla/Behaviours/ConductBoardManager.cs
+++ b/Utilla/Behaviours/ConductBoardManager.cs
@@ -1,5 +1,4 @@
-﻿using GorillaNetworking;
-using GorillaTag;
+﻿using GorillaTag;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;

--- a/Utilla/Constants.cs
+++ b/Utilla/Constants.cs
@@ -6,9 +6,9 @@
 
         internal const string Name = "Utilla";
 
-        internal const string Version = "1.6.24";
+        internal const string Version = "1.6.25";
 
-        public const string GamemodePrefix = "MODDED_";
+        public const string GamemodePrefix = "MODDED";
 
         internal const string InfoRepositoryURL = "https://raw.githubusercontent.com/developer9998/Utilla-Info/main";
     }

--- a/Utilla/Constants.cs
+++ b/Utilla/Constants.cs
@@ -8,7 +8,7 @@
 
         internal const string Version = "1.6.25";
 
-        public const string GamemodePrefix = "MODDED";
+        public const string GamemodePrefix = "MODDED_";
 
         internal const string InfoRepositoryURL = "https://raw.githubusercontent.com/developer9998/Utilla-Info/main";
     }

--- a/Utilla/Models/Gamemode.cs
+++ b/Utilla/Models/Gamemode.cs
@@ -72,7 +72,7 @@ namespace Utilla.Models
         {
             BaseGamemode = game_mode_type;
 
-            ID = game_mode_type.HasValue && !id.EndsWith(game_mode_type.Value.ToString()) ? string.Concat(id, game_mode_type) : id;
+            ID = game_mode_type.HasValue && !id.EndsWith(game_mode_type.Value.ToString()) ? string.Concat(id, "|", game_mode_type) : id;
             DisplayName = displayName;
 
             Logging.Message($"Constructed custom gamemode: {id} based on {(game_mode_type.HasValue ? game_mode_type.Value : "no")} type");

--- a/Utilla/Patches/EnumUtilExtPatches.cs
+++ b/Utilla/Patches/EnumUtilExtPatches.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using GorillaGameModes;
+using HarmonyLib;
+using Utilla.Utils;
+
+namespace Utilla.Patches;
+
+[HarmonyPatch]
+public class EnumUtilExtPatches
+{
+    public static MethodBase TargetMethod()
+    {
+        return typeof(EnumUtilExt)
+            .GetMethod(nameof(EnumUtilExt.GetName), BindingFlags.Public | BindingFlags.Static)
+            ?.MakeGenericMethod(typeof(GameModeType));
+    }
+    
+    public static bool Prefix(GameModeType e, ref string __result) {
+        if (int.TryParse(e.ToString(), out _)) {
+            string a = GameModeUtils.GetGameModeInstance(e).GameTypeName();
+            __result = a;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Utilla/Patches/GameModePatches.cs
+++ b/Utilla/Patches/GameModePatches.cs
@@ -1,0 +1,17 @@
+using Fusion;
+using HarmonyLib;
+
+namespace Utilla.Patches;
+
+[HarmonyPatch(typeof(GorillaGameManager)), HarmonyWrapSafe]
+public class GameModePatches
+{
+    [HarmonyPatch("GameTypeName"), HarmonyPrefix]
+    public static bool GameTypeNamePatch(GorillaGameManager __instance, ref string __result) {
+        if (int.TryParse(__instance.GameType().ToString(), out _)) {
+            __result = __instance.GameModeName();
+            return false;
+        }
+        return true;
+    }
+}

--- a/Utilla/Utilla.csproj
+++ b/Utilla/Utilla.csproj
@@ -35,13 +35,13 @@
 			<HintPath>$(GameAssemblyPath)\Cinemachine.dll</HintPath>
 		</Reference>
 		<Reference Include="Fusion.Runtime">
-			<HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Gorilla Tag\Gorilla Tag_Data\Managed\Fusion.Runtime.dll</HintPath>
+			<HintPath>$(GameAssemblyPath)\Fusion.Runtime.dll</HintPath>
 		</Reference>
 		<Reference Include="Mono.Security">
 			<HintPath>$(GameAssemblyPath)\Mono.Security.dll</HintPath>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
-		  <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Gorilla Tag\Gorilla Tag_Data\Managed\Newtonsoft.Json.dll</HintPath>
+		  <HintPath>$(GameAssemblyPath)\Newtonsoft.Json.dll</HintPath>
 		</Reference>
 		<Reference Include="Oculus.Platform">
 			<HintPath>$(GameAssemblyPath)\Oculus.Platform.dll</HintPath>


### PR DESCRIPTION
game mode strings now need to be separated with '|'. this pr fix's that for both base modded gamemodes and adding new gamemodes 

the old way would make 'MODDED_Casual' that would fail the check 
but 'MODDED|Casual' is fine.
